### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -8,6 +8,7 @@ haskell_library(
     name = "hs-msgpack-testsuite",
     srcs = glob(["src/**/*.*hs"]),
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     version = "0.1.1",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-msgpack-testsuite/14)
<!-- Reviewable:end -->
